### PR TITLE
[config.py] Add missing `config.source_code_url` value

### DIFF
--- a/chumweb/config.py
+++ b/chumweb/config.py
@@ -47,7 +47,7 @@ class Config:
     # Directory with {arch}-primary.xml.gz files downloaded from an earlier run.
     repo_data_dir: str | None = None
     user_agent: str = "chumweb/1.0"
-    source_code_url: str = ""
+    source_code_url: str = "https://github.com/sailfishos-chum/sailfishos-chum.github.io/"
     # The amount of featured apps to show on the home page
     featured_apps_count = 10
     # The amount of updated apps to show in the sidebar


### PR DESCRIPTION
The string `source_code_url` [only occurs twice](https://github.com/search?q=repo%3Asailfishos-chum%2Fsailfishos-chum.github.io%20source_code_url&type=code):
- [`config.py`, line 50](https://github.com/sailfishos-chum/sailfishos-chum.github.io/blob/master/chumweb/config.py#L50)
- [`about-generator.html`, line 13](https://github.com/sailfishos-chum/sailfishos-chum.github.io/blob/master/chumweb/www/views/pages/about-generator.html#L13)

I.e., there is no other user of this configuration parameter than `about-generator.html`.
<sub>I do not comprehend why this link defaulted to the page displayed (https://sailfishos-chum.github.io/about-generator.html), but so what, probably a property of the tooling used.</sub>

Fixes last paragraph of https://github.com/sailfishos-chum/sailfishos-chum.github.io/issues/13#issuecomment-1962353095.