### PR TITLE
Change nav div to ul

### DIFF
--- a/chumweb/www/static/style.css
+++ b/chumweb/www/static/style.css
@@ -90,6 +90,12 @@ header, header:not(.section-site-info), .section-underline{
     padding-left: 0;
 }
 
+.link-list li a {
+    padding: 0.5em 0;
+    font-weight: bold;
+    display: block;
+}
+
 pre {
     overflow-x: auto;
 }
@@ -350,10 +356,6 @@ body.architecture--i486 .pkg-download-i486 {
 
 /* Either support touch or it is a small device (since the pointer: coarse does not work on the SFOS browser */
 @media (pointer: coarse), (max-device-width: 800px){
-    .link-list li a {
-        padding: 0.5em 0;
-        display: block;
-    }
     .link-list li:not(:last-child) a {
         border-bottom: 1px dotted var(--color-fg);
     }

--- a/chumweb/www/views/layouts/base.html
+++ b/chumweb/www/views/layouts/base.html
@@ -34,14 +34,14 @@
                     </div>
                 </form>
             {% endblock search %}
-            <div class="section-menu link-list">
-                <p><b><a href="{{ "index.html" | to_public_url }}">Home</a></b></p>
-                <p><b><a href="{{ "about.html" | to_public_url }}">About</a></b></p>
-                <p><b><a href="{{ "apps/index-a.html" | to_public_url }}">All apps</a></b></p>
-                <p><b><a href="{{ "pkgs/index-a.html" | to_public_url }}">All packages</a></b></p>
-                <p><b><a href="{{ "apps/index-category-accessibility.html" | to_public_url }}">All apps by category</a></b></p>
-                <p><b><a href="{{ "pkgs/index-category-accessibility.html" | to_public_url }}">All packages by category</a></b></p>
-            </div>
+            <ul class="section-menu link-list">
+                <li><a href="{{ "index.html" | to_public_url }}">Home</a></li>
+                <li><a href="{{ "about.html" | to_public_url }}">About</a></li>
+                <li><a href="{{ "apps/index-a.html" | to_public_url }}">All apps</a></li>
+                <li><a href="{{ "pkgs/index-a.html" | to_public_url }}">All packages</a></li>
+                <li><a href="{{ "apps/index-category-accessibility.html" | to_public_url }}">All apps by category</a></li>
+                <li><a href="{{ "pkgs/index-category-accessibility.html" | to_public_url }}">All packages by category</a></li>
+            </ul>
         </nav>
         <footer class="section-site-footer section-secondary">
             <p>


### PR DESCRIPTION
Effectively reverts PR #18 (i.e. commit c3ec04b rsp. 2e7dbb8), but keeps the additional padding and makes the list menu bold.

This way, the navigation list dividers still show on touch screens, which was broken by accident on that commit.