### PR TITLE
Try to parse changelog lines and format them on the web

### DIFF
--- a/chumweb/package.py
+++ b/chumweb/package.py
@@ -206,7 +206,7 @@ class PackageApplicationType(StrEnum):
     firmware = enum.auto()
 
 
-CHANGELOG_LINE_REGEX = re.compile(r"^[ \t]*-\s*(?:\[(?P<section>[^]]+)])?\s*(?P<log>\w.*)$")
+CHANGELOG_LINE_REGEX = re.compile(r"^[ \t]*-\s*(?:\[(?P<section>[^]]+)])?\s*(?P<log>\S.*)$")
 @dataclass
 class ChangelogEntryLine:
     section: str

--- a/chumweb/repo_loader.py
+++ b/chumweb/repo_loader.py
@@ -103,7 +103,10 @@ def load_repo(obs_url: str, obs_project: str, obs_auth: Tuple[str, str], repo_ur
 
     data_paths: List[Dict[str, Path]]
     if "data_path" in kwargs:
-        data_paths = [{'primary': Path(kwargs["data_path"], f"{repo}.xml.gz")} for repo in repos]
+        data_paths = [{
+                'primary': Path(kwargs["data_path"], f"{repo}-primary.xml.gz"),
+                'other': Path(kwargs["data_path"], f"{repo}-other.xml.gz")
+            } for repo in repos]
     else:
         begin_step("Downloading repos")
         data_paths = [save_repo_data(urljoin(repo_url, repo_name + "/"), repo_name, out_dir) for repo_name in repos]

--- a/chumweb/www/views/pages/package.html
+++ b/chumweb/www/views/pages/package.html
@@ -1,5 +1,6 @@
 {% extends "layouts/base.html" %}
 {% import "parts/package-item.html" as package_item %}
+{% import "parts/changelog.html" as changelog %}
 
 {% block title %} {{ pkg.title }} — {{ super() }}{% endblock %}
 
@@ -66,17 +67,7 @@
         {% if pkg.changelog_entries|length > 0 %}
             <section>
                 <header><h2>Changelog</h2></header>
-                <h3>{{ pkg.changelog_entries[0].version }} ({{ pkg.changelog_entries[0].timestamp | format_date }})</h3>
-                <pre>{{ pkg.changelog_entries[0].text }}</pre>
-                {% if pkg.changelog_entries|length > 1 %}
-                    <details>
-                        <summary><h3 style="display: inline-block; margin: 0.5em 0;">Older changelogs</h3></summary>
-                        {% for entry in pkg.changelog_entries[1:] %}
-                            <h4>{{ entry.version }} ({{ entry.timestamp | format_date }})</h4>
-                            <pre>{{ entry.text }}</pre>
-                        {% endfor %}
-                    </details>
-                {% endif %}
+                {{ changelog.changelog(pkg) }}
             </section>
 
         {% endif %}

--- a/chumweb/www/views/parts/changelog.html
+++ b/chumweb/www/views/parts/changelog.html
@@ -1,0 +1,46 @@
+{% macro changelog_entry_grouped(entry, level=3) -%}
+    <h{{level}}> {{ entry.version }} ({{ entry.timestamp | format_date }}) </h{{level}}>
+    {%if entry.lines|length > 0 %}
+        <ul>
+        {% for line in entry.lines %}
+            {% if loop.index == 1 and line.section != "" or loop.index > 1 and line.section.casefold() != loop.previtem.section.casefold() %}
+            </ul>
+            <h{{ level + 1 }}>{{ line.section }} </h{{ level + 1 }}>
+            <ul>
+            {% endif %}
+            <li>{{ line.text }}</li>
+        {% endfor %}
+        </ul>
+    {% else %}
+    <pre>{{entry.text}}</pre>
+    {% endif %}
+{%- endmacro %}
+
+{% macro changelog_entry(entry, level=3) -%}
+    <h{{level}}> {{ entry.version }} ({{ entry.timestamp | format_date }}) </h{{level}}>
+    {%if entry.lines|length > 0 %}
+        <ul>
+        {% for line in entry.lines %}
+            {% if line.section == "" %}
+                <li> {{ line.text }}</li>
+            {% else %}
+                <li> <strong>[{{ line.section }}]</strong> {{ line.text }} </li>
+            {% endif %}
+        {% endfor %}
+        </ul>
+    {% else %}
+    <pre>{{entry.text}}</pre>
+    {% endif %}
+{%- endmacro %}
+
+{% macro changelog(pkg) -%}
+    {{ changelog_entry(pkg.changelog_entries[0]) }}
+    {% if pkg.changelog_entries|length > 1 %}
+        <details>
+            <summary><h3 style="display: inline-block; margin: 0.5em 0;">Older changelogs</h3></summary>
+            {% for entry in pkg.changelog_entries[1:] %}
+                {{ changelog_entry(entry, 4) }}
+            {% endfor %}
+        </details>
+    {% endif %}
+{%- endmacro %}


### PR DESCRIPTION
Parse the lines of a changelog entry using the somewhat standardised
method of writing changelog messages. The parsed messages will be
displayed in a nicely formatted way.

If the parser cannot make any sense out of it, it will fall back to
displaying the changelog in a good, old `<pre>`-block.